### PR TITLE
Enhancement: Native fmt string support for errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ if ok := err.(lathos.NotFound); ok {
 
 This reads ok (in my opinion not as nice as a lathos check though), but if you want to change the NotFound type, you need to update this throughout your code base where you check the errors. You may want to implement your own version of the NotFound error for example.
 
-## Useage
+## Usage
 
 Lathos is mostly made up of interfaces that when implemented on an error type give it a particular behaviour, these can be found in the [lathos.go](lathos.go) file.
 

--- a/errs/client.go
+++ b/errs/client.go
@@ -18,11 +18,11 @@ type ErrClient struct {
 	detail string
 }
 
-func newErrClient(code, detail string, a ...interface{}) ErrClient {
+func newErrClient(code, detail string) ErrClient {
 	return ErrClient{
 		id:     uuid.New().String(),
 		code:   code,
-		detail: fmt.Sprintf(detail, a...),
+		detail: detail,
 	}
 }
 
@@ -72,12 +72,21 @@ type ErrNotFound struct {
 // a particular error in code such as E404.
 // Detail can be supplied to give more context to the error, ie
 // "resource 123 does not exist".
-func NewErrNotFound(code, detail string, a ...interface{}) ErrNotFound {
-	c := newErrClient(code, detail, a...)
+func NewErrNotFound(code, detail string) ErrNotFound {
+	c := newErrClient(code, detail)
 	c.title = "Not found"
 	return ErrNotFound{
 		ErrClient: c,
 	}
+}
+
+// NewErrNotFoundf will create and return a new NotFound error.
+// You can supply a code which can be set in your application to identify
+// a particular error in code such as E404.
+// Detail can be supplied to give more context to the error, ie
+// "resource 123 does not exist".
+func NewErrNotFoundf(code, detail string, a ...interface{}) ErrNotFound {
+	return NewErrNotFound(code, fmt.Sprintf(detail, a...))
 }
 
 // NotFound implements the NotFound interface
@@ -97,12 +106,21 @@ type ErrDuplicate struct {
 // a particular error in code such as D001.
 // Detail can be supplied to give more context to the error, ie
 // "resource 123 already exists".
-func NewErrDuplicate(code, detail string, a ...interface{}) ErrDuplicate {
-	c := newErrClient(code, detail, a...)
+func NewErrDuplicate(code, detail string) ErrDuplicate {
+	c := newErrClient(code, detail)
 	c.title = "Item already exists"
 	return ErrDuplicate{
 		ErrClient: c,
 	}
+}
+
+// NewErrDuplicatef will create and return a new Duplicate error.
+// You can supply a code which can be set in your application to identify
+// a particular error in code such as D001.
+// Detail can be supplied to give more context to the error, ie
+// "resource 123 already exists".
+func NewErrDuplicatef(code, detail string, a ...interface{}) ErrDuplicate {
+	return NewErrDuplicate(code, fmt.Sprintf(detail, a...))
 }
 
 // Duplicate implements the Duplicate interface and
@@ -123,12 +141,22 @@ type ErrNotAuthenticated struct {
 // to show a custom message.
 // Detail can be supplied to give more context to the error, ie
 // "user not authenticated".
-func NewErrNotAuthenticated(code, detail string, a ...interface{}) ErrNotAuthenticated {
-	c := newErrClient(code, detail, a...)
+func NewErrNotAuthenticated(code, detail string) ErrNotAuthenticated {
+	c := newErrClient(code, detail)
 	c.title = "Not authenticated"
 	return ErrNotAuthenticated{
 		ErrClient: c,
 	}
+}
+
+// NewErrNotAuthenticatedf will create and return a new NotAuthenticated error.
+// You can supply a code which can be set in your application to identify
+// a particular error in code such as F001 which can be handled by clients
+// to show a custom message.
+// Detail can be supplied to give more context to the error, ie
+// "user not authenticated".
+func NewErrNotAuthenticatedf(code, detail string, a ...interface{}) ErrNotAuthenticated {
+	return NewErrNotAuthenticated(code, fmt.Sprintf(detail, a...))
 }
 
 // NotAuthenticated implements the NotAuthenticated interface
@@ -148,12 +176,21 @@ type ErrNotAuthorised struct {
 // a particular error in code such as F001.
 // Detail can be supplied to give more context to the error, ie
 // "user 123 cannot access resource".
-func NewErrNotAuthorised(code, detail string, a ...interface{}) ErrNotAuthorised {
-	c := newErrClient(code, detail, a...)
+func NewErrNotAuthorised(code, detail string) ErrNotAuthorised {
+	c := newErrClient(code, detail)
 	c.title = "Permission denied"
 	return ErrNotAuthorised{
 		ErrClient: c,
 	}
+}
+
+// NewErrNotAuthorisedf will create and return a new NotAuthorised error.
+// You can supply a code which can be set in your application to identify
+// a particular error in code such as F001.
+// Detail can be supplied to give more context to the error, ie
+// "user 123 cannot access resource".
+func NewErrNotAuthorisedf(code, detail string, a ...interface{}) ErrNotAuthorised {
+	return NewErrNotAuthorised(code, fmt.Sprintf(detail, a...))
 }
 
 // NotAuthorised implements the NotAuthorised interface
@@ -173,12 +210,21 @@ type ErrNotAvailable struct {
 // a particular error in code such as U001.
 // Detail can be supplied to give more context to the error, ie
 // "the service is not currently available".
-func NewErrNotAvailable(code, detail string, a ...interface{}) ErrNotAvailable {
-	c := newErrClient(code, detail, a...)
+func NewErrNotAvailable(code, detail string) ErrNotAvailable {
+	c := newErrClient(code, detail)
 	c.title = "Not available"
 	return ErrNotAvailable{
 		ErrClient: c,
 	}
+}
+
+// NewErrNotAvailablef will create and return a new NotAvailable error.
+// You can supply a code which can be set in your application to identify
+// a particular error in code such as U001.
+// Detail can be supplied to give more context to the error, ie
+// "the service is not currently available".
+func NewErrNotAvailablef(code, detail string, a ...interface{}) ErrNotAvailable {
+	return NewErrNotAvailable(code, fmt.Sprintf(detail, a...))
 }
 
 // Unavailable implements the Unavailable interface used
@@ -198,12 +244,21 @@ type ErrUnprocessable struct {
 // a particular error in code such as U001.
 // Detail can be supplied to give more context to the error, ie
 // "cannot process this request".
-func NewErrUnprocessable(code, detail string, a ...interface{}) ErrUnprocessable {
-	c := newErrClient(code, detail, a...)
+func NewErrUnprocessable(code, detail string) ErrUnprocessable {
+	c := newErrClient(code, detail)
 	c.title = "Unprocessable"
 	return ErrUnprocessable{
 		ErrClient: c,
 	}
+}
+
+// NewErrUnprocessablef will create and return a new Unprocessable error.
+// You can supply a code which can be set in your application to identify
+// a particular error in code such as U001.
+// Detail can be supplied to give more context to the error, ie
+// "cannot process this request".
+func NewErrUnprocessablef(code, detail string, a ...interface{}) ErrUnprocessable {
+	return NewErrUnprocessable(code, fmt.Sprintf(detail, a...))
 }
 
 // CannotProcess implements the Unprocessable interface

--- a/errs/client.go
+++ b/errs/client.go
@@ -1,6 +1,8 @@
 package errs
 
 import (
+	"fmt"
+
 	"github.com/google/uuid"
 )
 
@@ -16,11 +18,11 @@ type ErrClient struct {
 	detail string
 }
 
-func newErrClient(code, detail string) ErrClient {
+func newErrClient(code, detail string, a ...interface{}) ErrClient {
 	return ErrClient{
 		id:     uuid.New().String(),
 		code:   code,
-		detail: detail,
+		detail: fmt.Sprintf(detail, a...),
 	}
 }
 
@@ -70,8 +72,8 @@ type ErrNotFound struct {
 // a particular error in code such as E404.
 // Detail can be supplied to give more context to the error, ie
 // "resource 123 does not exist".
-func NewErrNotFound(code, detail string) ErrNotFound {
-	c := newErrClient(code, detail)
+func NewErrNotFound(code, detail string, a ...interface{}) ErrNotFound {
+	c := newErrClient(code, detail, a...)
 	c.title = "Not found"
 	return ErrNotFound{
 		ErrClient: c,
@@ -95,8 +97,8 @@ type ErrDuplicate struct {
 // a particular error in code such as D001.
 // Detail can be supplied to give more context to the error, ie
 // "resource 123 already exists".
-func NewErrDuplicate(code, detail string) ErrDuplicate {
-	c := newErrClient(code, detail)
+func NewErrDuplicate(code, detail string, a ...interface{}) ErrDuplicate {
+	c := newErrClient(code, detail, a...)
 	c.title = "Item already exists"
 	return ErrDuplicate{
 		ErrClient: c,
@@ -121,8 +123,8 @@ type ErrNotAuthenticated struct {
 // to show a custom message.
 // Detail can be supplied to give more context to the error, ie
 // "user not authenticated".
-func NewErrNotAuthenticated(code, detail string) ErrNotAuthenticated {
-	c := newErrClient(code, detail)
+func NewErrNotAuthenticated(code, detail string, a ...interface{}) ErrNotAuthenticated {
+	c := newErrClient(code, detail, a...)
 	c.title = "Not authenticated"
 	return ErrNotAuthenticated{
 		ErrClient: c,
@@ -146,8 +148,8 @@ type ErrNotAuthorised struct {
 // a particular error in code such as F001.
 // Detail can be supplied to give more context to the error, ie
 // "user 123 cannot access resource".
-func NewErrNotAuthorised(code, detail string) ErrNotAuthorised {
-	c := newErrClient(code, detail)
+func NewErrNotAuthorised(code, detail string, a ...interface{}) ErrNotAuthorised {
+	c := newErrClient(code, detail, a...)
 	c.title = "Permission denied"
 	return ErrNotAuthorised{
 		ErrClient: c,
@@ -171,8 +173,8 @@ type ErrNotAvailable struct {
 // a particular error in code such as U001.
 // Detail can be supplied to give more context to the error, ie
 // "the service is not currently available".
-func NewErrNotAvailable(code, detail string) ErrNotAvailable {
-	c := newErrClient(code, detail)
+func NewErrNotAvailable(code, detail string, a ...interface{}) ErrNotAvailable {
+	c := newErrClient(code, detail, a...)
 	c.title = "Not available"
 	return ErrNotAvailable{
 		ErrClient: c,
@@ -196,8 +198,8 @@ type ErrUnprocessable struct {
 // a particular error in code such as U001.
 // Detail can be supplied to give more context to the error, ie
 // "cannot process this request".
-func NewErrUnprocessable(code, detail string) ErrUnprocessable {
-	c := newErrClient(code, detail)
+func NewErrUnprocessable(code, detail string, a ...interface{}) ErrUnprocessable {
+	c := newErrClient(code, detail, a...)
 	c.title = "Unprocessable"
 	return ErrUnprocessable{
 		ErrClient: c,

--- a/errs/client_test.go
+++ b/errs/client_test.go
@@ -58,27 +58,27 @@ func Test_FmtString(t *testing.T) {
 		expErr error
 	}{
 		"err not found": {
-			err:    NewErrNotFound("test", "test %s", "format"),
+			err:    NewErrNotFoundf("test", "test %s", "format"),
 			expErr: errors.New("Not found: test format"),
 		},
 		"err new duplicate": {
-			err:    NewErrDuplicate("test", "test %s", "format"),
+			err:    NewErrDuplicatef("test", "test %s", "format"),
 			expErr: errors.New("Item already exists: test format"),
 		},
 		"err not authenticated": {
-			err:    NewErrNotAuthenticated("test", "test %s", "format"),
+			err:    NewErrNotAuthenticatedf("test", "test %s", "format"),
 			expErr: errors.New("Not authenticated: test format"),
 		},
 		"err not authorised": {
-			err:    NewErrNotAuthorised("test", "test %s", "format"),
+			err:    NewErrNotAuthorisedf("test", "test %s", "format"),
 			expErr: errors.New("Permission denied: test format"),
 		},
 		"err not available": {
-			err:    NewErrNotAvailable("test", "test %s", "format"),
+			err:    NewErrNotAvailablef("test", "test %s", "format"),
 			expErr: errors.New("Not available: test format"),
 		},
 		"err unprocessable": {
-			err:    NewErrUnprocessable("test", "test %s", "format"),
+			err:    NewErrUnprocessablef("test", "test %s", "format"),
 			expErr: errors.New("Unprocessable: test format"),
 		},
 	}

--- a/errs/client_test.go
+++ b/errs/client_test.go
@@ -24,15 +24,15 @@ func TestIsDuplicate(t *testing.T) {
 			expClient: true,
 			expDup:    true,
 		}, "wrapped duplicate error should return true if it implements Duplicate": {
-			err:       fmt.Errorf("my error %w",   NewErrDuplicate("test", "test")),
+			err:       fmt.Errorf("my error %w", NewErrDuplicate("test", "test")),
 			expClient: true,
 			expDup:    true,
 		}, "wrapped pkg/error duplicate error should return true if it implements Duplicate": {
-			err:       pkgerrs.Wrap(fmt.Errorf("my error %w",   NewErrDuplicate("test", "test")), "wrapped error"),
+			err:       pkgerrs.Wrap(fmt.Errorf("my error %w", NewErrDuplicate("test", "test")), "wrapped error"),
 			expClient: true,
 			expDup:    true,
 		}, "other error type should return false for duplicate check": {
-			err:       NewErrNotFound("test","test"),
+			err:       NewErrNotFound("test", "test"),
 			expClient: true,
 			expDup:    false,
 		}, "error not implementing interface should return false": {
@@ -47,6 +47,46 @@ func TestIsDuplicate(t *testing.T) {
 			is.Equal(false, lathos.IsBadRequest(test.err))
 			is.Equal(test.expClient, lathos.IsClientError(test.err))
 			is.Equal(test.expDup, lathos.IsDuplicate(test.err))
+		})
+	}
+}
+
+func Test_FmtString(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		err    error
+		expErr error
+	}{
+		"err not found": {
+			err:    NewErrNotFound("test", "test %s", "format"),
+			expErr: errors.New("Not found: test format"),
+		},
+		"err new duplicate": {
+			err:    NewErrDuplicate("test", "test %s", "format"),
+			expErr: errors.New("Item already exists: test format"),
+		},
+		"err not authenticated": {
+			err:    NewErrNotAuthenticated("test", "test %s", "format"),
+			expErr: errors.New("Not authenticated: test format"),
+		},
+		"err not authorised": {
+			err:    NewErrNotAuthorised("test", "test %s", "format"),
+			expErr: errors.New("Permission denied: test format"),
+		},
+		"err not available": {
+			err:    NewErrNotAvailable("test", "test %s", "format"),
+			expErr: errors.New("Not available: test format"),
+		},
+		"err unprocessable": {
+			err:    NewErrUnprocessable("test", "test %s", "format"),
+			expErr: errors.New("Unprocessable: test format"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			is := is.NewRelaxed(t)
+			is.Equal(test.err.Error(), test.expErr.Error())
 		})
 	}
 }


### PR DESCRIPTION
I find myself doing this a lot:
```go
return lathos.NewErrUnprocessable("OHNO1", fmt.Sprintf("id %s failed", myCoolID))
```

With this we can just do:
```go
return lathos.NewErrUnprocessable("OHNO1", "id %s failed", myCoolID)
```